### PR TITLE
Added two commands

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -51,6 +51,11 @@ commands:
       usage: /AdjustBonusClaimBlocks <player> <amount>
       permission: griefprevention.adjustclaimblocks
       aliases: acb
+   setblockbank:
+      description: Set the player's accrued blocks bank to the specified amount.
+      usage: /SetBlockBank <player> <amount>
+      permission: griefprevention.setblockbank
+      aliases: sbb
    deleteclaim:
       description: Deletes the claim you're standing in, even if it's not your claim.
       usage: /DeleteClaim
@@ -60,6 +65,10 @@ commands:
       description: Deletes all of another player's claims.
       usage: /DeleteAllClaims <player>
       permission: griefprevention.deleteclaims
+   resetclaims:
+      description: Deletes all of another player's claims AND resets their accrued block bank to the initial value.
+      usage: /ResetClaims <player>
+      permission: griefprevention.resetclaims
    adminclaims:
       description: Switches the shovel tool to administrative claims mode.
       usage: /AdminClaims

--- a/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1677,8 +1677,37 @@ public class GriefPrevention extends JavaPlugin
 			
 			return true;
 		}
-		
-		//deletealladminclaims
+
+                //resetclaims <player>
+                else if(cmd.getName().equalsIgnoreCase("resetclaims") && player != null)
+                {
+                        //requires exactly one parameter, the other player's name
+                        if(args.length != 1) return false;
+
+                        //try to find that player
+                        OfflinePlayer otherPlayer = this.resolvePlayer(args[0]);
+                        if(otherPlayer == null)
+                        {
+                                GriefPrevention.sendMessage(player, TextMode.Err, "Player not found.");
+                                return true;
+                        }
+
+                        //delete all that player's claims
+                        this.dataStore.deleteClaimsForPlayer(otherPlayer.getName(), true);
+                        //set claim blocks bank to zero
+                        PlayerData playerData = this.dataStore.getPlayerData(otherPlayer.getName());
+                        playerData.accruedClaimBlocks = GriefPrevention.instance.config_claims_initialBlocks;                        
+                        this.dataStore.savePlayerData(otherPlayer.getName(), playerData);
+
+                        GriefPrevention.sendMessage(player, TextMode.Success, "Deleted " + otherPlayer.getName() + "'s claims and set their block bank to the initial value.");
+
+                        //revert any current visualization
+                        Visualization.Revert(player);
+
+                        return true;
+                }
+
+                //deletealladminclaims
 		else if(cmd.getName().equalsIgnoreCase("deletealladminclaims"))
 		{
 			if(!player.hasPermission("griefprevention.deleteclaims"))
@@ -1750,7 +1779,43 @@ public class GriefPrevention extends JavaPlugin
 			return true;			
 		}
 		
-		//trapped
+                //setblockbank <player> <amount>
+                else if(cmd.getName().equalsIgnoreCase("setblockbank"))
+                {
+                        //requires exactly two parameters, the other player's name and the adjustment
+                        if(args.length != 2) return false;
+
+                        //find the specified player
+                        OfflinePlayer targetPlayer = this.resolvePlayer(args[0]);
+                        if(targetPlayer == null)
+                        {
+                                GriefPrevention.sendMessage(player, TextMode.Err, "Player \"" + args[0] + "\" not found.");
+                                return true;
+                        }
+
+                        //parse the adjustment amount
+                        int adjustment;
+                        try
+                        {
+                                adjustment = Integer.parseInt(args[1]);
+                        }
+                        catch(NumberFormatException numberFormatException)
+                        {
+                                return false;  //causes usage to be displayed
+                        }
+
+                        //give blocks to player
+                        PlayerData playerData = this.dataStore.getPlayerData(targetPlayer.getName());
+                        playerData.accruedClaimBlocks = GriefPrevention.instance.config_claims_initialBlocks;
+                        this.dataStore.savePlayerData(targetPlayer.getName(), playerData);
+
+                        GriefPrevention.sendMessage(player, TextMode.Success, "Adjusted " + targetPlayer.getName() + "'s bonus claim blocks by " + adjustment + ".  New total bonus blocks: " + playerData.bonusClaimBlocks + ".");
+                        GriefPrevention.AddLogEntry(player.getName() + " adjusted " + targetPlayer.getName() + "'s bonus claim blocks by " + adjustment + ".");
+
+                        return true;      
+                }
+
+                //trapped
 		else if(cmd.getName().equalsIgnoreCase("trapped") && player != null)
 		{
 			//FEATURE: empower players who get "stuck" in an area where they don't have permission to build to save themselves


### PR DESCRIPTION
Hi Tux!  I added two straightforward commands I use myself in managing my server:  SetBlockBank, which allows you to set how many accrued blocks a player has (useful when you need to distinguish bonus blocks for any reason) and ResetClaim, which returns a user to "like-new" state with no active claims and as many accrued blocks as they initially started with as per the config.yml.  It was a simple change, but as it might be useful to others, I'll let you decide if you'd like to include it in the main line.

Thanks a bunch!  You can reach me here or on bukkitdev as MKindy.
