### PR TITLE
Customizable 'TrashBlocks' and Wilderness placement delay

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -53,7 +53,7 @@ commands:
       aliases: acb
    transferclaimblocks:
       description: transfers claim blocks from one player to another.
-      usage: /TransferClaimBlocks <sourceplayer> <targetplayer>
+      usage: /TransferClaimBlocks <sourceplayer> <targetplayer> <amount>
       permission: griefprevention.transferclaimblocks
    deleteclaim:
       description: Deletes the claim you're standing in, even if it's not your claim.
@@ -176,7 +176,7 @@ permissions:
         default: op
     griefprevention.giveclaimblocks:
         description: Grants permission to give claim blocks to another player.
-        default:true
+        default:false
     griefprevention.transferclaimblocks:
         description: Grants permission to transfer claim blocks from one player to another.
         default: op

--- a/plugin.yml
+++ b/plugin.yml
@@ -51,6 +51,10 @@ commands:
       usage: /AdjustBonusClaimBlocks <player> <amount>
       permission: griefprevention.adjustclaimblocks
       aliases: acb
+   transferclaimblocks:
+      description: transfers claim blocks from one player to another.
+      usage: /TransferClaimBlocks <sourceplayer> <targetplayer>
+      permission: griefprevention.transferclaimblocks
    deleteclaim:
       description: Deletes the claim you're standing in, even if it's not your claim.
       usage: /DeleteClaim
@@ -146,6 +150,7 @@ permissions:
             griefprevention.ignoreclaims: true
             griefprevention.adminclaims: true
             griefprevention.adjustclaimblocks: true
+            griefprevention.transferclaimblocks: true
             griefprevention.deleteclaims: true
             griefprevention.spam: true
             griefprevention.lava: true
@@ -168,6 +173,12 @@ permissions:
         default: op
     griefprevention.adjustclaimblocks:
         description: Grants permission to add or remove bonus blocks from a player's account.
+        default: op
+    griefprevention.giveclaimblocks:
+        description: Grants permission to give claim blocks to another player.
+        default:true
+    griefprevention.transferclaimblocks:
+        description: Grants permission to transfer claim blocks from one player to another.
         default: op
     griefprevention.spam:
         description: Grants permission to send messages commands rapidly.

--- a/src/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -232,7 +232,7 @@ public class BlockEventHandler implements Listener
 			GriefPrevention.AddLogEntry("[Sign Placement] <" + player.getName() + "> " + lines.toString() + " @ " + GriefPrevention.getfriendlyLocationString(event.getBlock().getLocation()));
 			playerData.lastMessage = signMessage;
 			
-			if(!player.hasPermission("griefprevention.eavesdrop"))
+			if(!player.hasPermission("griefprevention.eavesdrop") && GriefPrevention.instance.config_sign_Eavesdrop)
 			{
 				Player [] players = GriefPrevention.instance.getServer().getOnlinePlayers();
 				for(int i = 0; i < players.length; i++)

--- a/src/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -57,6 +57,10 @@ import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.util.Vector;
 
 //event handlers related to blocks
+/**
+ * Listener class for Block-related Event handling.
+ * 
+ */
 public class BlockEventHandler implements Listener 
 {
 	//convenience reference to singleton datastore
@@ -70,7 +74,8 @@ public class BlockEventHandler implements Listener
 		this.dataStore = dataStore;
 		
 		//create the list of blocks which will not trigger a warning when they're placed outside of land claims
-		this.trashBlocks = new ArrayList<Material>();
+		this.trashBlocks = new ArrayList<Material>(GriefPrevention.instance.config_trash_blocks);
+		/*this.trashBlocks = new ArrayList<Material>();
 		this.trashBlocks.add(Material.COBBLESTONE);
 		this.trashBlocks.add(Material.TORCH);
 		this.trashBlocks.add(Material.DIRT);
@@ -78,7 +83,7 @@ public class BlockEventHandler implements Listener
 		this.trashBlocks.add(Material.GRAVEL);
 		this.trashBlocks.add(Material.SAND);
 		this.trashBlocks.add(Material.TNT);
-		this.trashBlocks.add(Material.WORKBENCH);
+		this.trashBlocks.add(Material.WORKBENCH);*/
 	}
 	
 	//when a block is damaged...
@@ -203,7 +208,7 @@ public class BlockEventHandler implements Listener
 		}
 	}
 	
-	//when a player places a sign...
+		//when a player places a sign...
 	@EventHandler(ignoreCancelled = true)
 	public void onSignChanged(SignChangeEvent event)
 	{
@@ -382,10 +387,10 @@ public class BlockEventHandler implements Listener
 		//FEATURE: warn players when they're placing non-trash blocks outside of their claimed areas
 		else if(GriefPrevention.instance.config_claims_warnOnBuildOutside && !this.trashBlocks.contains(block.getType()) && GriefPrevention.instance.claimsEnabledForWorld(block.getWorld()) && playerData.claims.size() > 0)
 		{
-			if(--playerData.unclaimedBlockPlacementsUntilWarning <= 0)
+			if(--playerData.unclaimedBlockPlacementsUntilWarning <= 0 && GriefPrevention.instance.config_claims_wildernessBlocksDelay!=0)
 			{
 				GriefPrevention.sendMessage(player, TextMode.Warn, Messages.BuildingOutsideClaims);
-				playerData.unclaimedBlockPlacementsUntilWarning = 15;
+				playerData.unclaimedBlockPlacementsUntilWarning = GriefPrevention.instance.config_claims_wildernessBlocksDelay;
 				
 				if(playerData.lastClaim != null && playerData.lastClaim.allowBuild(player) == null)
 				{

--- a/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -144,6 +144,7 @@ public class GriefPrevention extends JavaPlugin
 	public boolean config_fireDestroys;								//whether fire destroys blocks outside of claims
 	
 	public boolean config_addItemsToClaimedChests;					//whether players may add items to claimed chests by left-clicking them
+	public boolean config_sign_Eavesdrop;                           //whether to allow sign eavesdropping at all.
 	public boolean config_eavesdrop; 								//whether whispered messages will be visible to administrators
 	public ArrayList<String> config_eavesdrop_whisperCommands;		//list of whisper commands to eavesdrop on
 	
@@ -344,7 +345,8 @@ public class GriefPrevention extends JavaPlugin
 		this.config_claims_wildernessBlocksDelay = config.getInt("GriefPrevention.Claims.WildernessWarningBlockCount",15); //number of blocks,0 will disable the wilderness warning.
 		
 		
-		
+		this.config_sign_Eavesdrop = config.getBoolean("GriefPrevention.SignEavesDrop",true);
+		outConfig.set("GriefPrevention.SignEavesDrop", this.config_sign_Eavesdrop);
 		this.config_claims_preventTheft = config.getBoolean("GriefPrevention.Claims.PreventTheft", true);
 		this.config_claims_protectCreatures = config.getBoolean("GriefPrevention.Claims.ProtectCreatures", true);
 		this.config_claims_preventButtonsSwitches = config.getBoolean("GriefPrevention.Claims.PreventButtonsSwitches", true);


### PR DESCRIPTION
List of "Trash" blocks were hard coded into BlockEventHandler.java for specific block types. This change allows Trash Blocks to be set via the GriefPrevention.Claims.TrashBlocks configuration setting. The default is the original hard-coded value.

When placing non-trash blocks in the wilderness, the plugin counts down from a hard-coded value of 15, so every 15th block will trigger the text message about other players being able to change the claim. This value is now read from the configuration entry GriefPrevention.Claims.WildernessWarningBlockCount. It defaults to the original hard-coded 15 as well. 0 will disable the message entirely, like the WarnWhenBuildingOutsideClaims configuration entry.
