### PR TITLE
Don't cause a memory leak if a world used for protections unloads, make protections work if a world used for protections is unloaded then reloaded.

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -628,7 +628,7 @@ public class BlockEventHandler implements Listener
 	public void onBlockFromTo (BlockFromToEvent spreadEvent)
 	{
 		//don't track fluid movement in worlds where claims are not enabled
-		if(!GriefPrevention.instance.config_claims_enabledWorlds.contains(spreadEvent.getBlock().getWorld())) return;
+		if(!GriefPrevention.instance.config_claims_enabledWorlds.contains(spreadEvent.getBlock().getWorld().getName())) return;
 		
 		//always allow fluids to flow straight down
 		if(spreadEvent.getFace() == BlockFace.DOWN) return;

--- a/src/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -540,7 +540,7 @@ public abstract class DataStore
 		}
 		
 		//creative mode claims always go to bedrock
-		if(GriefPrevention.instance.config_claims_enabledCreativeWorlds.contains(world))
+		if(GriefPrevention.instance.config_claims_enabledCreativeWorlds.contains(world.getName()))
 		{
 			smally = 2;
 		}

--- a/src/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/EntityEventHandler.java
@@ -82,7 +82,7 @@ class EntityEventHandler implements Listener
 		}
 		
 		//don't allow the wither to break blocks, when the wither is determined, too expensive to constantly check for claimed blocks
-		else if(event.getEntityType() == EntityType.WITHER && GriefPrevention.instance.config_claims_enabledWorlds.contains(event.getBlock().getWorld()))
+		else if(event.getEntityType() == EntityType.WITHER && GriefPrevention.instance.config_claims_enabledWorlds.contains(event.getBlock().getWorld().getName()))
 		{
 			event.setCancelled(true);
 		}
@@ -114,7 +114,7 @@ class EntityEventHandler implements Listener
 		
 		//FEATURE: explosions don't destroy blocks when they explode near or above sea level in standard worlds
 		boolean isCreeper = (explodeEvent.getEntity() != null && explodeEvent.getEntity() instanceof Creeper);
-		if( location.getWorld().getEnvironment() == Environment.NORMAL && GriefPrevention.instance.config_claims_enabledWorlds.contains(location.getWorld()) && ((isCreeper && GriefPrevention.instance.config_blockSurfaceCreeperExplosions) || (!isCreeper && GriefPrevention.instance.config_blockSurfaceOtherExplosions)))			
+		if( location.getWorld().getEnvironment() == Environment.NORMAL && GriefPrevention.instance.config_claims_enabledWorlds.contains(location.getWorld().getName()) && ((isCreeper && GriefPrevention.instance.config_blockSurfaceCreeperExplosions) || (!isCreeper && GriefPrevention.instance.config_blockSurfaceOtherExplosions)))
 		{
 			for(int i = 0; i < blocks.size(); i++)
 			{

--- a/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -69,8 +69,8 @@ public class GriefPrevention extends JavaPlugin
 	public DataStore dataStore;
 	
 	//configuration variables, loaded/saved from a config.yml
-	public ArrayList<World> config_claims_enabledWorlds;			//list of worlds where players can create GriefPrevention claims
-	public ArrayList<World> config_claims_enabledCreativeWorlds;	//list of worlds where additional creative mode anti-grief rules apply
+	public ArrayList<String> config_claims_enabledWorlds;			//list of worlds where players can create GriefPrevention claims
+	public ArrayList<String> config_claims_enabledCreativeWorlds;	//list of worlds where additional creative mode anti-grief rules apply
 	
 	//blame:BC_Programming, configurable "Trash" blocks that do not notify
 	public List<Material> config_trash_blocks=null;
@@ -214,7 +214,7 @@ public class GriefPrevention extends JavaPlugin
 		}
 		
 		//validate that list
-		this.config_claims_enabledWorlds = new ArrayList<World>();
+		this.config_claims_enabledWorlds = new ArrayList<String>();
 		for(int i = 0; i < claimsEnabledWorldNames.size(); i++)
 		{
 			String worldName = claimsEnabledWorldNames.get(i);
@@ -225,7 +225,7 @@ public class GriefPrevention extends JavaPlugin
 			}
 			else
 			{
-				this.config_claims_enabledWorlds.add(world);
+				this.config_claims_enabledWorlds.add(world.getName());
 			}
 		}
 		
@@ -249,7 +249,7 @@ public class GriefPrevention extends JavaPlugin
 		}
 		
 		//validate that list
-		this.config_claims_enabledCreativeWorlds = new ArrayList<World>();
+		this.config_claims_enabledCreativeWorlds = new ArrayList<String>();
 		for(int i = 0; i < creativeClaimsEnabledWorldNames.size(); i++)
 		{
 			String worldName = creativeClaimsEnabledWorldNames.get(i);
@@ -260,7 +260,7 @@ public class GriefPrevention extends JavaPlugin
 			}
 			else
 			{
-				this.config_claims_enabledCreativeWorlds.add(world);
+				this.config_claims_enabledCreativeWorlds.add(world.getName());
 			}
 		}
 		
@@ -2397,7 +2397,7 @@ public class GriefPrevention extends JavaPlugin
 	//checks whether players can create claims in a world
 	public boolean claimsEnabledForWorld(World world)
 	{
-		return this.config_claims_enabledWorlds.contains(world);
+		return this.config_claims_enabledWorlds.contains(world.getName());
 	}
 	
 	//checks whether players siege in a world
@@ -2679,7 +2679,7 @@ public class GriefPrevention extends JavaPlugin
 	//determines whether creative anti-grief rules apply at a location
 	public boolean creativeRulesApply(Location location)
 	{
-		return this.config_claims_enabledCreativeWorlds.contains(location.getWorld());
+		return this.config_claims_enabledCreativeWorlds.contains(location.getWorld().getName());
 	}
 	public String allowBuild(Player player, Location location)
 	{
@@ -2702,7 +2702,7 @@ public class GriefPrevention extends JavaPlugin
 			}
 			
 			//no building in survival wilderness when that is configured
-			else if(this.config_claims_noBuildOutsideClaims && this.config_claims_enabledWorlds.contains(location.getWorld()))
+			else if(this.config_claims_noBuildOutsideClaims && this.config_claims_enabledWorlds.contains(location.getWorld().getName()))
 			{
 				return this.dataStore.getMessage(Messages.NoBuildOutsideClaims) + "  " + this.dataStore.getMessage(Messages.SurvivalBasicsDemoAdvertisement);
 			}
@@ -2743,7 +2743,7 @@ public class GriefPrevention extends JavaPlugin
 				return reason;
 			}
 			
-			else if(this.config_claims_noBuildOutsideClaims && this.config_claims_enabledWorlds.contains(location.getWorld()))
+			else if(this.config_claims_noBuildOutsideClaims && this.config_claims_enabledWorlds.contains(location.getWorld().getName()))
 			{
 				return this.dataStore.getMessage(Messages.NoBuildOutsideClaims) + "  " + this.dataStore.getMessage(Messages.SurvivalBasicsDemoAdvertisement);
 			}

--- a/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -934,7 +934,7 @@ class PlayerEventHandler implements Listener
 		}
 		
 		//otherwise no wilderness dumping (unless underground) in worlds where claims are enabled
-		else if(GriefPrevention.instance.config_claims_enabledWorlds.contains(block.getWorld()))
+		else if(GriefPrevention.instance.config_claims_enabledWorlds.contains(block.getWorld().getName()))
 		{
 			if(block.getY() >= GriefPrevention.instance.getSeaLevel(block.getWorld()) - 5 && !player.hasPermission("griefprevention.lava"))
 			{

--- a/src/me/ryanhamshire/GriefPrevention/tasks/EntityCleanupTask.java
+++ b/src/me/ryanhamshire/GriefPrevention/tasks/EntityCleanupTask.java
@@ -24,6 +24,7 @@ import java.util.List;
 import me.ryanhamshire.GriefPrevention.Claim;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Boat;
@@ -35,24 +36,28 @@ import org.bukkit.entity.Vehicle;
 
 //this main thread task revisits the location of a partially chopped tree from several minutes ago
 //if any part of the tree is still there and nothing else has been built in its place, remove the remaining parts
-public class EntityCleanupTask implements Runnable 
+public class EntityCleanupTask implements Runnable
 {
 	//where to start cleaning in the list of entities
 	private double percentageStart;
-	
+
 	public EntityCleanupTask(double percentageStart)
 	{
 		this.percentageStart = percentageStart;
 	}
-	
+
 	@Override
-	public void run() 
+	public void run()
 	{
-		ArrayList<World> worlds = GriefPrevention.instance.config_claims_enabledCreativeWorlds;
-		
-		for(int i = 0; i < worlds.size(); i++)
+		ArrayList<String> worlds = GriefPrevention.instance.config_claims_enabledCreativeWorlds;
+
+		for (String worldName : worlds)
 		{
-			World world = worlds.get(i);
+			World world = Bukkit.getWorld(worldName);
+			if (world == null)
+			{
+				continue;
+			}
 			
 			List<Entity> entities = world.getEntities();
 			
@@ -129,7 +134,7 @@ public class EntityCleanupTask implements Runnable
 			{
 				//check its entity count and remove any extras
 				claim.allowMoreEntities();
-			}			
+			}
 		}
 		
 		//schedule the next run of this task, in 3 minutes (20L is approximately 1 second)


### PR DESCRIPTION
Signed-off-by: Ross Allan rallanpcl@gmail.com
