### PR TITLE
Remove debug code that significantly slows down servers

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/me/ryanhamshire/GriefPrevention/Claim.java
@@ -334,9 +334,7 @@ public class Claim {
 		Material material = BlocktoCheck.getType();
 		WorldConfig wc = GriefPrevention.instance.getWorldCfg(player.getWorld());
 		// if under siege, some blocks will be breakable
-        System.out.println("allowBreak.");
 		if (this.siegeData != null) {
-            System.out.println("siegeData is not null.");
 			// and the breaking player is the attacker...
 
 			boolean breakable = false;
@@ -350,8 +348,6 @@ public class Claim {
 				}
 			}
 			breakable = breakable || BrokenBlockInfo.canBreak(BlocktoCheck.getLocation());
-            System.out.println(BlocktoCheck.getType().name() + " Breakable:" + breakable);
-            System.out.println("player:" + player.getName() + " Siege player:" + siegeData.attacker.getName())   ;
 			if (breakable && player.getName().equalsIgnoreCase(siegeData.attacker.getName())) {
 				// if breakable, player is the attacker, and
 				if (wc.getSiegeBlockRevert()) {


### PR DESCRIPTION
"allowBuild" is repeated approximately 20 times a second - ie on every tick.

I found this out when we updated to the most recent dev build, and "allowBuild" was constantly being put in chat. This gets rid of that debug code, and should fix those problems.
