### PR TITLE
Catch the error for an undefined class of org.bukkit.entity.Horse

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -743,8 +743,11 @@ public class GriefPrevention extends JavaPlugin {
 	}
 
 	public boolean isHorse(Entity entitytest) {
-
-		return entitytest instanceof Horse;
+		try{
+			return entitytest instanceof Horse;
+		}catch(NoClassDefFoundError err){
+			return false
+		}
 
 	}
 


### PR DESCRIPTION
Prevents pre-1.6.x bukkit servers from throwing errors on the missing Horse entity.
