### PR TITLE
Check for ID's that return null materials and prevent them from being added.

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/Configuration/WorldConfig.java
+++ b/src/me/ryanhamshire/GriefPrevention/Configuration/WorldConfig.java
@@ -1054,7 +1054,10 @@ public class WorldConfig {
         // add found items if applicable.
         if (GriefPrevention.instance.ModdedBlocks != null) {
             for (MaterialInfo mi : GriefPrevention.instance.ModdedBlocks.FoundAccess.getMaterials()) {
-                accessTrustStrings.add(mi.toString());
+        	String miString = mi.toString();
+        	if (miString != null){
+        	    accessTrustStrings.add(miString);
+        	}
             }
         }
         // parse the list we got from the cfg file. This will ADD to the list,

--- a/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -1098,6 +1098,13 @@ public class GriefPrevention extends JavaPlugin {
 			// null value returned indicates an error parsing the string from
 			// the config file
 			if (materialInfo == null) {
+				// ignore and remove null entries
+				if(stringsToParse.get(i) == null){
+				    stringsToParse.remove(i);
+				    i -= 1;
+				    continue;
+				}
+				
 				// show error in log
 				GriefPrevention.AddLogEntry("ERROR: Unable to read a material entry from the config file.  Please update your config.yml.");
 

--- a/src/me/ryanhamshire/GriefPrevention/MaterialInfo.java
+++ b/src/me/ryanhamshire/GriefPrevention/MaterialInfo.java
@@ -164,7 +164,11 @@ public class MaterialInfo {
                    //46:*:X46$0
 
         StringBuffer sb = new StringBuffer();
-        sb.append(Material.getMaterial(this.typeID).name());
+        Material material = Material.getMaterial(this.typeID);
+        if(material == null){
+            return null;
+        }
+        sb.append(material.name());
         sb.append(":");
         sb.append(this.allDataValues?"*":String.valueOf(this.data));
 		if(this.description!=null) sb.append(":" + description);


### PR DESCRIPTION
Some mods have the item ID on block {} but never register them on the server. This prevents this IDs from generating NullPointerExceptions.
