### PR TITLE
Added deprecated getSubClaimId() method

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/me/ryanhamshire/GriefPrevention/Claim.java
@@ -895,6 +895,14 @@ public class Claim {
 	}
 
 	/**
+	 * @deprecated use Claim.getID() instead
+	 */
+	@Deprecated
+	public Long getSubClaimID() {
+		return this.id
+	}
+
+	/**
 	 * Returns a copy of the location representing lower x, y, z limits
 	 * 
 	 * @return

--- a/src/me/ryanhamshire/GriefPrevention/Claim.java
+++ b/src/me/ryanhamshire/GriefPrevention/Claim.java
@@ -899,7 +899,7 @@ public class Claim {
 	 */
 	@Deprecated
 	public Long getSubClaimID() {
-		return this.id
+		return this.parent == null ? null : this.id;
 	}
 
 	/**


### PR DESCRIPTION
BC, I recommend leaving this in for your dev builds so it doesn't break extensions between beta and dev.  It can be removed once your ready to release a 3rd beta since it didn't exist prior to 7.8.  If your getting ready to release a beta soon, you can ignore this.
