### PR TITLE
Adds YAML Auto Save Feature and Universal Importer

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -43,6 +43,10 @@ public abstract class DataStore {
 	public final static String dataLayerFolderPath = "plugins" + File.separator + "GriefPrevention";
 	public final static String configFilePath = dataLayerFolderPath + File.separator + "config.yml";
 	
+    public enum DataStoreType {
+        FLAT, MYSQL, YAML, THREADED;
+    }
+
 
 	// path information, for where stuff stored on disk is well... stored
 	/**
@@ -79,7 +83,7 @@ public abstract class DataStore {
 	// timestamp for each siege cooldown to end
 	private HashMap<String, Long> siegeCooldownRemaining = new HashMap<String, Long>();
 
-
+    public abstract DataStoreType getType();
 
 	/**
 	 * Adds a claim to the datastore, making it an effective claim.
@@ -1039,6 +1043,8 @@ public abstract class DataStore {
 
 	public abstract boolean hasPlayerData(String playerName);
 
+    public abstract ConcurrentHashMap<String, Integer> getAllGroupBonusBlocks();
+
 	// increments the claim ID and updates secondary storage to be sure it's
 	// saved
 	abstract void incrementNextClaimID();
@@ -1654,35 +1660,71 @@ public abstract class DataStore {
 
 	abstract void writeClaimToStorage(Claim claim);
 
+    public final DataStore importDataStore(DataStore Source) throws IllegalArgumentException {
+        Debugger.Write("Importing DataStore from " + Source.getType().toString() + " to " + this.getType().toString() + ".", DebugLevel.Informational);
+        if(Source.getType() == this.getType()) {
+            throw new IllegalArgumentException("The source DataStore may not be of the same type.");
+        }
+
+        if(this.getNextClaimID() < Source.getNextClaimID()) {
+            Debugger.Write("Importing Next Claim ID.", DebugLevel.Informational);
+            this.setNextClaimID(Source.getNextClaimID());
+        }
+
+        //transfer claims from Source to target.
+        //conflicts will be ignored
+        ForceLoadAllClaims(Source);
+        for(Claim cc : Source.getClaimArray()){
+            Debugger.Write("Importing claim " + cc.getID() + ".", DebugLevel.Informational);
+            this.addClaim(cc);
+        }
+
+        // Migrate the player data
+        for(PlayerData p : Source.getAllPlayerData()){
+            //save this PlayerData into the target.
+            Debugger.Write("Importing Player " + p.playerName + ".", DebugLevel.Informational);
+            this.savePlayerData(p.playerName, p);
+        }
+
+        Map<String, Integer> bonuses = Source.getAllGroupBonusBlocks();
+        for(String s : bonuses.keySet()) {
+            Debugger.Write("Importing bonus group " + s + ".", DebugLevel.Informational);
+            this.saveGroupBonusBlocks(s, bonuses.get(s));
+        }
+        Debugger.Write("Importing Complete", DebugLevel.Informational);
+        return this;
+    }
+
 	public static void migrateData(DataStore Source,DataStore Target){
 		migrateData(new DataStore[]{Source},new DataStore[]{Target});
 	}
-	
-	public static void migrateData(DataStore[] Sources,DataStore[] Targets){
-		
-		//migrate from the given Source to the given Target.
-		//first try to force all claims to be loaded in the Source DataStore.
-		for(DataStore Source:Sources){
-			
-				
-			ForceLoadAllClaims(Source);
-			
-			for(DataStore Target:Targets){
-				//transfer claims from Source to target.
-				for(Claim cc:Source.claims){
-					Target.addClaim(cc);
-				}
-				
-				for(PlayerData p:Source.getAllPlayerData()){
-					//save this PlayerData into the target.
-					
-				    Target.savePlayerData(p.playerName, p);
-				    
-				}
-			}
-		}
-		
-		
-	}
-	
+
+
+    public static void migrateData(DataStore[] Sources,DataStore[] Targets){
+
+        //migrate from the given Source to the given Target.
+        //first try to force all claims to be loaded in the Source DataStore.
+        for(DataStore Source:Sources){
+
+
+            ForceLoadAllClaims(Source);
+
+            for(DataStore Target:Targets){
+                //transfer claims from Source to target.
+                for(Claim cc:Source.claims){
+                    Target.addClaim(cc);
+                }
+
+                for(PlayerData p:Source.getAllPlayerData()){
+                    //save this PlayerData into the target.
+
+                    Target.savePlayerData(p.playerName, p);
+
+                }
+            }
+        }
+
+
+    }
+
 }

--- a/src/me/ryanhamshire/GriefPrevention/DatabaseDataStore.java
+++ b/src/me/ryanhamshire/GriefPrevention/DatabaseDataStore.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 import me.ryanhamshire.GriefPrevention.Debugger.DebugLevel;
 import me.ryanhamshire.GriefPrevention.exceptions.WorldNotFoundException;
@@ -48,6 +49,10 @@ public class DatabaseDataStore extends DataStore {
 		initialize(Source, Target);
 
 	}
+
+    public DataStoreType getType() {
+        return DataStoreType.MYSQL;
+    }
 
 	@Override
 	synchronized void close() {
@@ -182,6 +187,36 @@ public class DatabaseDataStore extends DataStore {
 		this.setNextClaimID(this.nextClaimID + 1);
 	}
 
+    @Override
+    public ConcurrentHashMap<String, Integer> getAllGroupBonusBlocks() {
+        // load group data into memory
+        ConcurrentHashMap<String, Integer> bonuses = new ConcurrentHashMap<>();
+        try {
+            Statement statement = databaseConnection.createStatement();
+            ResultSet results = statement.executeQuery("SELECT * FROM griefprevention_playerdata;");
+
+
+            while (results.next()) {
+                String name = results.getString("name");
+
+                // ignore non-groups. all group names start with a dollar sign.
+                if (!name.startsWith("$"))
+                    continue;
+
+                String groupName = name.substring(1);
+                if (groupName == null || groupName.isEmpty())
+                    continue; // defensive coding, avoid unlikely cases
+
+                int groupBonusBlocks = results.getInt("bonusblocks");
+
+                bonuses.put(groupName, groupBonusBlocks);
+            }
+        } catch (SQLException ex) {
+            return null;
+        }
+        return bonuses;
+    }
+
 	@Override
 	void initialize(ConfigurationSection Source, ConfigurationSection Target) throws Exception {
 
@@ -267,27 +302,11 @@ public class DatabaseDataStore extends DataStore {
 		}
 
 		// load group data into memory
-		Statement statement = databaseConnection.createStatement();
-		ResultSet results = statement.executeQuery("SELECT * FROM griefprevention_playerdata;");
-
-		while (results.next()) {
-			String name = results.getString("name");
-
-			// ignore non-groups. all group names start with a dollar sign.
-			if (!name.startsWith("$"))
-				continue;
-
-			String groupName = name.substring(1);
-			if (groupName == null || groupName.isEmpty())
-				continue; // defensive coding, avoid unlikely cases
-
-			int groupBonusBlocks = results.getInt("bonusblocks");
-
-			this.permissionToBonusBlocksMap.put(groupName, groupBonusBlocks);
-		}
+    	this.permissionToBonusBlocksMap = getAllGroupBonusBlocks();
 
 		// load next claim number into memory
-		results = statement.executeQuery("SELECT * FROM griefprevention_nextclaimid;");
+        Statement statement = databaseConnection.createStatement();
+        ResultSet results = statement.executeQuery("SELECT * FROM griefprevention_nextclaimid;");
 
 		// if there's nothing yet, add it
 		if (!results.next()) {

--- a/src/me/ryanhamshire/GriefPrevention/ThreadedDataStore.java
+++ b/src/me/ryanhamshire/GriefPrevention/ThreadedDataStore.java
@@ -4,6 +4,7 @@ import org.bukkit.World;
 
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 /**
@@ -34,6 +35,10 @@ public class ThreadedDataStore extends DataStore{
         }
 
 
+    }
+
+    public DataStoreType getType() {
+        return DataStoreType.THREADED;
     }
 
     public ThreadedDataStore(DataStore Internal){
@@ -73,6 +78,11 @@ public class ThreadedDataStore extends DataStore{
     @Override
     public boolean hasPlayerData(String playerName) {
         return false;  //To change body of implemented methods use File | Settings | File Templates.
+    }
+
+    @Override
+    public ConcurrentHashMap<String, Integer> getAllGroupBonusBlocks() {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Ok, this is the last little bit of this implementation, I added an auto save feature since YAML is normally cached and it was only saving on server reload or stop.  This gives an option in yamlconfig.yml to set the number of minutes (default 60) between autosaves.

It also adds the importer.  I originally tried to update the migrate methods I found, but I think they were being overridden and I didn't want to break something so I made a new one.  It's usage is pretty simple:

this.dataStore = new YamlDataStore().importDataStore(new FlatFileDataStore());

This is in the abstract class so it will work with any of the DataStore types (you can now go back from SQL to flat file using this).  Of course I had to make a few small tweaks to all the DataStore types in order to make this work, I extracted the group bonus loading part of the initialize methods into it's own method (which is abstract) and I added a convenience enum DataStoreType and an abstract getType() method.

I did quite a few tests and it all seems solid and ready to be implemented in the main class.
